### PR TITLE
feat(angular): add overrides property to config

### DIFF
--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -1,9 +1,10 @@
 import 'zone.js';
 import 'zone.js/testing';
-import { Type } from '@angular/core';
+import { Component, Type } from '@angular/core';
 import {
   ComponentFixture,
   getTestBed,
+  MetadataOverride,
   TestBed,
   TestModuleMetadata,
 } from '@angular/core/testing';
@@ -16,12 +17,16 @@ export interface TestBedConfig<T extends object> extends TestModuleMetadata {
   // this extends the normal angular TestBed config
   // and allows us to pass component Input() props as part of the config object
   inputs?: { [P in keyof T]: T[P] }
+
+  // see https://angular.io/guide/testing-components-scenarios#override-component-providers
+  overrides?: MetadataOverride<Component>
 }
 
 function init<T extends object>(config: TestBedConfig<T>): TestBed {
   const testBed: TestBed = getTestBed();
 
   testBed.resetTestEnvironment();
+  testBed.resetTestingModule();
   testBed.initTestEnvironment(
     BrowserDynamicTestingModule,
     platformBrowserDynamicTesting(),
@@ -42,6 +47,10 @@ export function mount<T extends object>(
   config: TestBedConfig<T> = {}
 ): ComponentFixture<T> {
   const testBed: TestBed = init(config);
+  
+  if (config?.overrides) {
+    testBed.overrideComponent(component, config.overrides)
+  }
 
   testBed.compileComponents();
   const fixture = testBed.createComponent(component);

--- a/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
+++ b/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
@@ -1,13 +1,27 @@
+import 'zone.js';
+import 'zone.js/testing';
 import { provideMockStore } from "@ngrx/store/testing"
 import { mount } from "../../../../projects/angular/src/public-api"
 import { NgrxCounterComponent } from "./ngrx-counter.component"
+import { initialState } from '../count-store/count.reducer';
 
 describe('NgRxCounterComponent', () => {
     beforeEach(() => {
-        mount(NgrxCounterComponent, { providers: [provideMockStore({ })]})
+        mount(NgrxCounterComponent, {
+            overrides: {
+                set: { 
+                    providers: [provideMockStore()]
+                }
+            }
+        })
     })
-
     it('can mount', () => {
         cy.get('h3').contains('NgRx Counter: 0');
+    })
+
+    it('can increment the count by dispatching action and selectors updates', () => {
+        cy.get('h3').contains('NgRx Counter: 0');
+        cy.get('button').contains('Increment +').click();
+        cy.get('h3').contains('NgRx Counter: 1');
     })
 })


### PR DESCRIPTION
This PR adds support for `fixture.componentOverrides()` by adding an `overrides` property to the `TestBedConfig`