### PR TITLE
fix(angular): adds hack for Mocha has already been patched with Zone error

### DIFF
--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -1,5 +1,11 @@
 import 'zone.js';
+
+/**
+ * @hack fixes "Mocha has already been patched with Zone" error.
+ */
+(globalThis as any)['Mocha']['__zone_patch__'] = false;
 import 'zone.js/testing';
+
 import { Component, Type } from '@angular/core';
 import {
   ComponentFixture,

--- a/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
+++ b/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
@@ -1,9 +1,6 @@
-import 'zone.js';
-import 'zone.js/testing';
 import { provideMockStore } from "@ngrx/store/testing"
 import { mount } from "../../../../projects/angular/src/public-api"
 import { NgrxCounterComponent } from "./ngrx-counter.component"
-import { initialState } from '../count-store/count.reducer';
 
 describe('NgRxCounterComponent', () => {
     beforeEach(() => {


### PR DESCRIPTION
This adds a hack for the `Mocha has already been patched with Zone error`