### PR TITLE
feat: add componenet override examples and fix broken tests

### DIFF
--- a/projects/angular/src/lib/angular.component.spec.ts
+++ b/projects/angular/src/lib/angular.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AngularComponent } from './angular.component';
+
+describe('AngularComponent', () => {
+  let component: AngularComponent;
+  let fixture: ComponentFixture<AngularComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ AngularComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AngularComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/angular/src/lib/angular.component.ts
+++ b/projects/angular/src/lib/angular.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'lib-angular',
+  template: `
+    <p>
+      angular works with {{title}} !
+    </p>
+  `,
+  styles: [
+  ]
+})
+export class AngularComponent {
+  @Input() title = 'default';
+
+}

--- a/projects/angular/src/lib/angular.module.ts
+++ b/projects/angular/src/lib/angular.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { AngularComponent } from './angular.component';
+
+
+
+@NgModule({
+  declarations: [
+    AngularComponent
+  ],
+  imports: [
+  ],
+  exports: [
+    AngularComponent
+  ]
+})
+export class AngularModule { }

--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -1,23 +1,18 @@
-import { Component, Type } from '@angular/core';
+import { Type } from '@angular/core';
 import {
   ComponentFixture,
-  getTestBed,
-  MetadataOverride,
-  TestBed,
-  TestModuleMetadata,
+  getTestBed, TestBed,
+  TestModuleMetadata
 } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
+  platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
 export interface TestBedConfig<T extends object> extends TestModuleMetadata {
   // this extends the normal angular TestBed config
   // and allows us to pass component Input() props as part of the config object
   inputs?: { [P in keyof T]: T[P] }
-
-  // see https://angular.io/guide/testing-components-scenarios#override-component-providers
-  overrides?: MetadataOverride<Component>
 }
 
 function init<T extends object>(config: TestBedConfig<T>): TestBed {
@@ -44,10 +39,6 @@ export function mount<T extends object>(
   config: TestBedConfig<T> = {}
 ): ComponentFixture<T> {
   const testBed: TestBed = init(config);
-  
-  if (config?.overrides) {
-    testBed.overrideComponent(component, config.overrides)
-  }
 
   testBed.compileComponents();
   const fixture = testBed.createComponent(component);

--- a/projects/angular/tsconfig.spec.json
+++ b/projects/angular/tsconfig.spec.json
@@ -5,6 +5,6 @@
     "outDir": "../../out-tsc/spec",
     "types": ["jasmine"]
   },
-  "files": ["src/test.ts", "src/polyfills.ts"],
+  "files": ["src/test.ts"],
   "include": ["**/*.spec.ts", "**/*.d.ts"]
 }

--- a/src/app/count/count.component.html
+++ b/src/app/count/count.component.html
@@ -7,3 +7,7 @@
 <hr />
 
 <app-ngrx-counter></app-ngrx-counter>
+
+<hr />
+
+<app-overrides></app-overrides>

--- a/src/app/count/count.module.ts
+++ b/src/app/count/count.module.ts
@@ -7,6 +7,7 @@ import { ObservablesComponent } from './observables/observables.component';
 import { CountStoreModule } from './count-store/count-store.module';
 import { NgrxCounterComponent } from './ngrx-counter/ngrx-counter.component';
 import { ObservablesService } from './observables/observables.service';
+import { OverridesComponent } from './overrides/overrides.component';
 
 
 
@@ -15,7 +16,8 @@ import { ObservablesService } from './observables/observables.service';
     CountComponent,
     TestOutputButtonComponent,
     ObservablesComponent,
-    NgrxCounterComponent
+    NgrxCounterComponent,
+    OverridesComponent
   ],
   providers: [ObservablesService],
   imports: [

--- a/src/app/count/overrides/overrides.component.cy.ts
+++ b/src/app/count/overrides/overrides.component.cy.ts
@@ -1,0 +1,22 @@
+import { mount } from "../../../../projects/angular/src/public-api"
+import { OverridesComponent } from "./overrides.component"
+
+describe('OverridesComponent', () => {
+    beforeEach(() => {
+        mount(OverridesComponent)
+    });
+
+    it('can mount', () => {
+        cy.get('p').contains('overrides works ')
+    })
+
+    it('increments every second', () => {
+        cy.get('p').contains('overrides works ');
+        cy.wait(1000);
+        cy.get('p').contains('overrides works 0');
+        cy.wait(1000);
+        cy.get('p').contains('overrides works 1');
+        cy.wait(4000);
+        cy.get('p').contains('overrides works 5');
+    })
+})

--- a/src/app/count/overrides/overrides.component.html
+++ b/src/app/count/overrides/overrides.component.html
@@ -1,0 +1,1 @@
+<p>overrides works {{ ticker$ | async }} </p>

--- a/src/app/count/overrides/overrides.component.spec.ts
+++ b/src/app/count/overrides/overrides.component.spec.ts
@@ -1,0 +1,31 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverridesComponent } from './overrides.component';
+import { OverridesService } from './overrides.service';
+
+describe('OverridesComponent', () => {
+  let component: OverridesComponent;
+  let fixture: ComponentFixture<OverridesComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ OverridesComponent ],
+    }).overrideComponent(
+      OverridesComponent, {
+      set: { providers: [
+        { provide: OverridesService }
+      ]}
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverridesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/count/overrides/overrides.component.ts
+++ b/src/app/count/overrides/overrides.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { OverridesService } from './overrides.service';
+
+@Component({
+  selector: 'app-overrides',
+  templateUrl: './overrides.component.html',
+  styleUrls: ['./overrides.component.scss'],
+  providers: [OverridesService]
+})
+export class OverridesComponent {
+  ticker$ = this.service.tick$;
+
+  constructor(private readonly service: OverridesService) { }
+
+}

--- a/src/app/count/overrides/overrides.service.spec.ts
+++ b/src/app/count/overrides/overrides.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+
+import { OverridesService } from './overrides.service';
+
+describe('OverridesService', () => {
+  let service: OverridesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OverridesService]
+    });
+    service = TestBed.inject(OverridesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/count/overrides/overrides.service.ts
+++ b/src/app/count/overrides/overrides.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, timer } from 'rxjs';
+
+@Injectable()
+export class OverridesService {
+  tick$: Observable<number> = timer(1000, 1000);
+}


### PR DESCRIPTION
This PR adds an example of an Angular Component that has a custom provider (override) in the component decorator.

This also fixes some broken `.spec` files