### PR TITLE
fix(angular-dev-server): add babel-linker

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'cypress';
-import { devServer } from './projects/angular-dev-server/src/public-api'
+import { devServer } from 'cypress-angular-dev-server';
 
 export default defineConfig({
   component: {

--- a/projects/angular-dev-server/ng-package.json
+++ b/projects/angular-dev-server/ng-package.json
@@ -2,6 +2,10 @@
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/angular-dev-server",
   "lib": {
-    "entryFile": "src/public-api.ts"
+    "entryFile": "src/public-api.ts",
+    "umdModuleIds": {
+      "@cypress/webpack-dev-server": "../../node_modules/@cypress/webpack-dev-server",
+      "@ngtools/webpack": "../../node_modules/@ngtools/webpack"
+    }
   }
 }

--- a/projects/angular-dev-server/package.json
+++ b/projects/angular-dev-server/package.json
@@ -1,9 +1,10 @@
 {
   "name": "cypress-angular-dev-server",
-  "version": "0.0.11",
+  "version": "0.0.14",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",
+    "@angular/compiler-cli": ">=12",
     "@ngtools/webpack": ">=12",
     "@cypress/webpack-dev-server": ">=1.8.1"
   },

--- a/projects/angular-dev-server/package.json
+++ b/projects/angular-dev-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-angular-dev-server",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",

--- a/projects/angular-dev-server/src/lib/devServer.ts
+++ b/projects/angular-dev-server/src/lib/devServer.ts
@@ -3,7 +3,7 @@ import { generateTsConfig } from "./generateTsConfig";
 import { getWebpackConfig } from "./getWebpackConfig";
 import { dirSync } from 'tmp';
 
-export function devServer(cypressDevServerConfig: Cypress.DevServerConfig): Promise<ResolvedDevServerConfig> {
+export async function devServer(cypressDevServerConfig: Cypress.DevServerConfig): Promise<ResolvedDevServerConfig> {
     const { config  } = cypressDevServerConfig;
     const { specPattern, projectRoot  } = config;
     
@@ -12,9 +12,11 @@ export function devServer(cypressDevServerConfig: Cypress.DevServerConfig): Prom
 
     // This generates the tsconfig.cy.json file in the temporary directory from above
     generateTsConfig(specPattern, projectRoot, tempDir);
+
+    const webpackConfig = await getWebpackConfig(tempDir);
     
     return startDevServer(
         cypressDevServerConfig,
-        { webpackConfig: getWebpackConfig(tempDir) }
+        { webpackConfig }
     )
 }

--- a/projects/angular-dev-server/src/lib/generateTsConfig.spec.ts
+++ b/projects/angular-dev-server/src/lib/generateTsConfig.spec.ts
@@ -1,4 +1,4 @@
-import { generateTsConfig, generateTsConfigContent } from "./generateTsConfig";
+import { generateTsConfigContent } from "./generateTsConfig";
 
 describe('generateTsConfig', () => {
   const projectRoot = '/blah/blah2';

--- a/projects/angular-dev-server/src/lib/getWebpackConfig.spec.ts
+++ b/projects/angular-dev-server/src/lib/getWebpackConfig.spec.ts
@@ -1,8 +1,9 @@
 import { AngularWebpackPlugin } from "@ngtools/webpack"
 import { getWebpackConfig } from "./getWebpackConfig";
 import { Configuration } from 'webpack';
+import linkerPlugin from '@angular/compiler-cli/linker/babel';
 describe('getWebpackConfig', () => {
-    it('should prepend the tmpDir to the tsconfig path and return the Webpack Configuration', () => {
+    it('should prepend the tmpDir to the tsconfig path and return the Webpack Configuration', async() => {
   
         // arrange
         const tmpDir = '/myTempDir/123456789/tmp'
@@ -18,6 +19,17 @@ describe('getWebpackConfig', () => {
                   test: /(\.scss|\.sass)$/,
                   use: ['raw-loader', 'sass-loader'],
                 },
+                {
+                  test: /\.m?js$/,
+                  use: {
+                    loader: 'babel-loader',
+                    options: {
+                      plugins: [linkerPlugin],
+                      compact: false,
+                      cacheDirectory: true,
+                    }
+                  }
+                }
               ],
             },
             resolve: {
@@ -31,7 +43,7 @@ describe('getWebpackConfig', () => {
         }
 
         // act
-        const actual = getWebpackConfig(tmpDir);
+        const actual = await getWebpackConfig(tmpDir);
 
         // assert
         expect(actual).toEqual(expected);

--- a/projects/angular-dev-server/src/lib/getWebpackConfig.ts
+++ b/projects/angular-dev-server/src/lib/getWebpackConfig.ts
@@ -1,26 +1,41 @@
 import { AngularWebpackPlugin } from "@ngtools/webpack";
 import { Configuration } from "webpack";
 
-export const getWebpackConfig = (tmpDir: string): Configuration => ({
-  mode: 'development',
-  module: {
-    rules: [
-      {
-        test: /\.[jt]sx?$/,
-        loader: '@ngtools/webpack',
+export async function getWebpackConfig(tmpDir: string): Promise<Configuration> {
+  const linkerPlugin = await import('@angular/compiler-cli/linker/babel');
+
+  return {
+      mode: 'development',
+      module: {
+        rules: [
+          {
+            test: /\.[jt]sx?$/,
+            loader: '@ngtools/webpack',
+          },
+          {
+            test: /(\.scss|\.sass)$/,
+            use: ['raw-loader', 'sass-loader'],
+          },
+          {
+            test: /\.m?js$/,
+            use: {
+              loader: 'babel-loader',
+              options: {
+                plugins: [linkerPlugin],
+                compact: false,
+                cacheDirectory: true,
+              }
+            }
+          }
+        ],
       },
-      {
-        test: /(\.scss|\.sass)$/,
-        use: ['raw-loader', 'sass-loader'],
+      resolve: {
+          extensions: ['.ts', '.js'],
       },
-    ],
-  },
-  resolve: {
-      extensions: ['.ts', '.js'],
-  },
-  plugins: [
-      new AngularWebpackPlugin({
-          tsconfig: `${tmpDir}/tsconfig.cy.json`
-      }),
-  ],
-})
+      plugins: [
+          new AngularWebpackPlugin({
+              tsconfig: `${tmpDir}/tsconfig.cy.json`
+          }),
+      ],
+    }
+}

--- a/projects/angular-dev-server/src/lib/getWebpackConfig.ts
+++ b/projects/angular-dev-server/src/lib/getWebpackConfig.ts
@@ -21,7 +21,7 @@ export async function getWebpackConfig(tmpDir: string): Promise<Configuration> {
             use: {
               loader: 'babel-loader',
               options: {
-                plugins: [linkerPlugin],
+                plugins: [linkerPlugin.default],
                 compact: false,
                 cacheDirectory: true,
               }

--- a/projects/angular-dev-server/tsconfig.lib.json
+++ b/projects/angular-dev-server/tsconfig.lib.json
@@ -3,7 +3,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/lib",
-    "target": "es2015",
+    "target": "ES2018",
+    "module": "ESNext",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,

--- a/projects/angular-dev-server/tsconfig.lib.prod.json
+++ b/projects/angular-dev-server/tsconfig.lib.prod.json
@@ -6,6 +6,6 @@
     "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
-    "compilationMode": "partial",
+    "compilationMode": "partial"
   }
 }

--- a/src/app/app.component.cy.ts
+++ b/src/app/app.component.cy.ts
@@ -1,5 +1,5 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { mount } from '../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
 

--- a/src/app/count/count.component.cy.ts
+++ b/src/app/count/count.component.cy.ts
@@ -1,6 +1,6 @@
 import { TestBed } from "@angular/core/testing"
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
-import { mount } from "../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { CountComponent } from "./count.component"
 import { ObservablesService } from "./observables/observables.service"
 

--- a/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
+++ b/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
@@ -1,6 +1,6 @@
 import 'zone.js/testing';
 import { MockStore, provideMockStore } from "@ngrx/store/testing"
-import { mount } from "../../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { NgrxCounterComponent } from "./ngrx-counter.component"
 import { selectCount } from '../count-store/count.selectors';
 import { TestBed } from '@angular/core/testing';

--- a/src/app/count/observables/observables.component.cy.ts
+++ b/src/app/count/observables/observables.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from "../../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { ObservablesComponent } from "./observables.component"
 import { ObservablesService } from "./observables.service";
 

--- a/src/app/count/overrides/overrides.component.cy.ts
+++ b/src/app/count/overrides/overrides.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from "../../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { OverridesComponent } from "./overrides.component"
 
 describe('OverridesComponent', () => {

--- a/src/app/count/test-output-button/test-output-button.component.cy.ts
+++ b/src/app/count/test-output-button/test-output-button.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from "../../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { TestOutputButtonComponent } from "./test-output-button.component"
 
 describe('TestOutputButtonComponent', () => {

--- a/src/app/home/card/card.component.cy.ts
+++ b/src/app/home/card/card.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { CardComponent } from './card.component';
 
 describe('CardComponent', () => {

--- a/src/app/home/home.component.cy.ts
+++ b/src/app/home/home.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from "../../../projects/angular/src/public-api"
+import { mount } from "cypress-angular-component-testing"
 import { HomeComponent } from "./home.component"
 
 describe('HomeComponent', () => {

--- a/src/app/home/next-steps/next-steps.component.cy.ts
+++ b/src/app/home/next-steps/next-steps.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { NextStepsComponent } from './next-steps.component';
 
 describe('NextStepsComponent', () => {

--- a/src/app/home/resources/resources.component.cy.ts
+++ b/src/app/home/resources/resources.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { ResourcesComponent } from './resources.component';
 
 describe('ResourcesComponent', () => {

--- a/src/app/home/rocket/rocket.component.cy.ts
+++ b/src/app/home/rocket/rocket.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { RocketComponent } from './rocket.component';
 
 describe('RocketComponent', () => {

--- a/src/app/home/round-card-buttons/round-card-buttons.component.cy.ts
+++ b/src/app/home/round-card-buttons/round-card-buttons.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { RoundCardButtonsComponent } from './round-card-buttons.component';
 
 describe('RoundCardButtonsComponent', () => {

--- a/src/app/shared/footer/footer.component.cy.ts
+++ b/src/app/shared/footer/footer.component.cy.ts
@@ -1,4 +1,4 @@
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {

--- a/src/app/shared/toolbar/toolbar.component.cy.ts
+++ b/src/app/shared/toolbar/toolbar.component.cy.ts
@@ -1,5 +1,5 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { mount } from '../../../../projects/angular/src/public-api';
+import { mount } from 'cypress-angular-component-testing';
 import { ToolbarComponent } from './toolbar.component';
 
 describe('ToolbarComponent', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
       "angular-dev-server": [
         "dist/angular-dev-server/angular-dev-server",
         "dist/angular-dev-server"
-      ]
+      ],
+      "cypress-angular-dev-server": ["projects/angular-dev-server/src/public-api"],
+      "cypress-angular-component-testing": ["projects/angular/src/public-api"]
     },
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
This PR adds babel linker to resolve [this issue](https://github.com/angular/angular/issues/44026):

It also adds tsconfig paths for the library so we aren't doing relative paths in the angular app

It also adds `umdModuleIds` in the `ng-package.json` for those peer deps shows as warnings in the terminal

Releases v.0.0.15