### PR TITLE
ref(angular): change the response type from mount

### DIFF
--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-angular-component-testing",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",

--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -34,13 +34,15 @@ function init<T extends object>(config: TestBedConfig<T>): TestBed {
   return testBed;
 }
 
-export function mount<T extends object>(
+export type MountResponse<T extends object> = { fixture: ComponentFixture<T>, testBed: TestBed, component: T }
+
+export async function mount<T extends object>(
   component: Type<T>,
-  config: TestBedConfig<T> = {}
-): ComponentFixture<T> {
+  config: TestBedConfig<T> = {},
+  autoDetectChanges = true
+): Promise<MountResponse<T>> {
   const testBed: TestBed = init(config);
 
-  testBed.compileComponents();
   const fixture = testBed.createComponent(component);
   let componentInstance: T = fixture.componentInstance;
 
@@ -49,11 +51,11 @@ export function mount<T extends object>(
     componentInstance = Object.assign(componentInstance, config.inputs);
   }
 
-  fixture.whenStable().then(() => {
-    // This needs to be set to true so that change detection is automatically detected
-    // Not sure if there would be a use case to not support autoDetectChanges(true) 
-    fixture.autoDetectChanges(true);
-  })
+  await fixture.whenStable();
 
-  return fixture;
+  // This needs to be set to true so that change detection is automatically detected
+  // Not sure if there would be a use case to not support autoDetectChanges(true) 
+  fixture.autoDetectChanges(autoDetectChanges);
+
+  return { fixture, testBed, component: componentInstance };
 }

--- a/src/app/app.component.cy.ts
+++ b/src/app/app.component.cy.ts
@@ -4,8 +4,8 @@ import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
 
 describe('AppComponent', () => {
-  beforeEach(() => {
-    mount(AppComponent, { imports: [AppModule, RouterTestingModule] });
+  beforeEach(async () => {
+    await mount(AppComponent, { imports: [AppModule, RouterTestingModule] });
   });
 
   it('can mount', () => {

--- a/src/app/count/count.component.cy.ts
+++ b/src/app/count/count.component.cy.ts
@@ -7,8 +7,8 @@ import { ObservablesService } from "./observables/observables.service"
 describe('CountComponent', () => {
     let store: MockStore;
 
-    beforeEach(() => {
-        mount(CountComponent, { providers: [ObservablesService, provideMockStore()]})
+    beforeEach(async() => {
+        await mount(CountComponent, { providers: [ObservablesService, provideMockStore()]})
 
         store = TestBed.inject(MockStore);
     })

--- a/src/app/count/observables/observables.component.cy.ts
+++ b/src/app/count/observables/observables.component.cy.ts
@@ -1,10 +1,14 @@
-import { mount } from "cypress-angular-component-testing"
-import { ObservablesComponent } from "./observables.component"
+import { mount } from "cypress-angular-component-testing";
+import { MountResponse } from "projects/angular/src/lib/mount";
+import { filter } from "rxjs/operators";
+import { ObservablesComponent } from "./observables.component";
 import { ObservablesService } from "./observables.service";
 
 describe('Observables', () => {
-    beforeEach(() => {
-        mount(ObservablesComponent, { providers: [ObservablesService]});
+    let response: MountResponse<ObservablesComponent>
+
+    beforeEach(async () => {
+        response = await mount(ObservablesComponent, { providers: [ObservablesService]}, false);
     })
 
     it('can mount', () => {
@@ -16,12 +20,15 @@ describe('Observables', () => {
     it('can increment the count by clicking the add button which updates the observables next value in the service and it renders the new value in the component', () => {
         cy.get('h3').contains('Observable Service Count: 0');
         cy.get('button').contains('Add +').click();
+        response.component.count$.pipe(filter(val => val > 0)).subscribe(() => response.fixture.detectChanges())
         cy.get('h3').contains('Observable Service Count: 1');
     })
 
     it('can decrement the count by clicking the subtract button which updates the observables next value in the service and it renders the new value in the component', () => {
         cy.get('h3').contains('Observable Service Count: 0');
         cy.get('button').contains('Subtract -').click();
+        response.component.count$.pipe(filter(val => val < 0)).subscribe(() => response.fixture.detectChanges())
+        response.fixture.detectChanges();
         cy.get('h3').contains('Observable Service Count: -1')   
     })
 })

--- a/src/app/count/overrides/overrides.component.cy.ts
+++ b/src/app/count/overrides/overrides.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from "cypress-angular-component-testing"
 import { OverridesComponent } from "./overrides.component"
 
 describe('OverridesComponent', () => {
-    beforeEach(() => {
-        mount(OverridesComponent)
+    beforeEach(async () => {
+        await mount(OverridesComponent)
     });
 
     it('can mount', () => {

--- a/src/app/count/test-output-button/test-output-button.component.cy.ts
+++ b/src/app/count/test-output-button/test-output-button.component.cy.ts
@@ -2,22 +2,22 @@ import { mount } from "cypress-angular-component-testing"
 import { TestOutputButtonComponent } from "./test-output-button.component"
 
 describe('TestOutputButtonComponent', () => {
-    it('can mount the component', () => {
-        mount(TestOutputButtonComponent)
+    it('can mount the component', async () => {
+        await mount(TestOutputButtonComponent)
         cy.get('h3').contains('Total Clicks: 0')
         cy.get('button').contains('Add +');
     })
 
-    it('updates the clickCounter on button click', () => {
-        mount(TestOutputButtonComponent);
+    it('updates the clickCounter on button click', async () => {
+        await mount(TestOutputButtonComponent);
         cy.get('h3').contains('Total Clicks: 0');
         cy.get('button').click();
         cy.get('h3').contains('Total Clicks: 1');
     })
 
-    it('emits the next value on click', () => {
-        const fixture = mount(TestOutputButtonComponent)
-        cy.spy(fixture.componentInstance.count, 'emit').as('countEmitted');
+    it('emits the next value on click', async () => {
+        const result = await mount(TestOutputButtonComponent)
+        cy.spy(result.component.count, 'emit').as('countEmitted');
         cy.get('button').click();
         cy.get('@countEmitted').should('have.been.calledOnceWith', 1);
     })

--- a/src/app/home/card/card.component.cy.ts
+++ b/src/app/home/card/card.component.cy.ts
@@ -1,14 +1,14 @@
 import { mount } from 'cypress-angular-component-testing';
 import { CardComponent } from './card.component';
 
-describe('CardComponent', () => {
-  it('should render a card with empty defaults', () => {
-    mount(CardComponent);
+describe('CardComponent', async () => {
+  it('should render a card with empty defaults', async () => {
+    await mount(CardComponent);
     cy.get('a.card').should('exist');
   });
 
-  it('add Input props to Card Component', () => {
-    mount(CardComponent, {
+  it('add Input props to Card Component', async () => {
+    await mount(CardComponent, {
       inputs: { href: 'https://docs.cypress.io', title: 'Card Title' },
     });
     cy.get('a.card[href="https://docs.cypress.io"]').should('exist');

--- a/src/app/home/home.component.cy.ts
+++ b/src/app/home/home.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from "cypress-angular-component-testing"
 import { HomeComponent } from "./home.component"
 
 describe('HomeComponent', () => {
-    beforeEach(() => {
-        mount(HomeComponent)
+    beforeEach(async () => {
+        await mount(HomeComponent)
     })
 
     it('should render the child components', () => {

--- a/src/app/home/next-steps/next-steps.component.cy.ts
+++ b/src/app/home/next-steps/next-steps.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from 'cypress-angular-component-testing';
 import { NextStepsComponent } from './next-steps.component';
 
 describe('NextStepsComponent', () => {
-  beforeEach(() => {
-    mount(NextStepsComponent);
+  beforeEach(async () => {
+    await mount(NextStepsComponent);
   });
 
   it('should have a title of Next Steps', () => {

--- a/src/app/home/resources/resources.component.cy.ts
+++ b/src/app/home/resources/resources.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from 'cypress-angular-component-testing';
 import { ResourcesComponent } from './resources.component';
 
 describe('ResourcesComponent', () => {
-  beforeEach(() => {
-    mount(ResourcesComponent);
+  beforeEach(async () => {
+    await mount(ResourcesComponent);
   });
 
   it('renders component with title of Resources', () => {

--- a/src/app/home/rocket/rocket.component.cy.ts
+++ b/src/app/home/rocket/rocket.component.cy.ts
@@ -2,14 +2,14 @@ import { mount } from 'cypress-angular-component-testing';
 import { RocketComponent } from './rocket.component';
 
 describe('RocketComponent', () => {
-  it('should render with an empty title', () => {
-    mount(RocketComponent);
+  it('should render with an empty title', async () => {
+    await mount(RocketComponent);
     cy.get('.card').contains('app is running!');
   });
 
-  it('should render with title passed in via Input', () => {
+  it('should render with title passed in via Input', async () => {
     const title = 'My Test App';
-    mount(RocketComponent, { inputs: { title } });
+    await mount(RocketComponent, { inputs: { title } });
     cy.get('.card').contains(`${title} app is running!`);
   });
 });

--- a/src/app/home/round-card-buttons/round-card-buttons.component.cy.ts
+++ b/src/app/home/round-card-buttons/round-card-buttons.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from 'cypress-angular-component-testing';
 import { RoundCardButtonsComponent } from './round-card-buttons.component';
 
 describe('RoundCardButtonsComponent', () => {
-  beforeEach(() => {
-    mount(RoundCardButtonsComponent);
+  beforeEach(async () => {
+    await mount(RoundCardButtonsComponent);
   });
 
   it('should render the correct round card buttons', () => {

--- a/src/app/shared/footer/footer.component.cy.ts
+++ b/src/app/shared/footer/footer.component.cy.ts
@@ -2,8 +2,8 @@ import { mount } from 'cypress-angular-component-testing';
 import { FooterComponent } from './footer.component';
 
 describe('FooterComponent', () => {
-  beforeEach(() => {
-    mount(FooterComponent);
+  beforeEach(async () => {
+    await mount(FooterComponent);
   });
 
   it('should render with Love Angular?', () => {

--- a/src/app/shared/toolbar/toolbar.component.cy.ts
+++ b/src/app/shared/toolbar/toolbar.component.cy.ts
@@ -3,29 +3,29 @@ import { mount } from 'cypress-angular-component-testing';
 import { ToolbarComponent } from './toolbar.component';
 
 describe('ToolbarComponent', () => {
-  it('should render the default title of Welcome', () => {
-    mount(ToolbarComponent, { imports: [RouterTestingModule]});
+  it('should render the default title of Welcome', async () => {
+    await mount(ToolbarComponent, { imports: [RouterTestingModule]});
     cy.get('.toolbar span').contains('Welcome');
   });
 
-  it('should render a title with the title passed via prop', () => {
+  it('should render a title with the title passed via prop', async () => {
     const title = 'My Test Title';
-    const fixture = mount(ToolbarComponent, { inputs: { title }, imports: [RouterTestingModule]});
+    const fixture = await mount(ToolbarComponent, { inputs: { title }, imports: [RouterTestingModule]});
     cy.get('.toolbar span').contains(title);
   });
 
-  it('should have an image with an alt of Angular Logo', () => {
-    mount(ToolbarComponent, { imports: [RouterTestingModule] });
+  it('should have an image with an alt of Angular Logo', async () => {
+    await mount(ToolbarComponent, { imports: [RouterTestingModule] });
     cy.get('img[alt="Angular Logo"]').should('be.visible');
   });
 
-  it('should have a twitter icon with a link to @angular', () => {
-    mount(ToolbarComponent, { imports: [RouterTestingModule] });
+  it('should have a twitter icon with a link to @angular', async () => {
+    await mount(ToolbarComponent, { imports: [RouterTestingModule] });
     cy.get('.toolbar a[href="https://twitter.com/angular"]').should('exist');
   });
 
-  it('should have a youtube icon with a link to youtube.com/angular', () => {
-    mount(ToolbarComponent, { imports: [RouterTestingModule] });
+  it('should have a youtube icon with a link to youtube.com/angular', async () => {
+    await mount(ToolbarComponent, { imports: [RouterTestingModule] });
     cy.get('.toolbar a[href="https://youtube.com/angular"]').should('exist');
   });
 });


### PR DESCRIPTION
This PR is based upon feedback from Shai Reznik
- Add a flag to not `autoDetectChanges`
- Remove the `.compileComponent()` on the fixture as it is not necessary (since cypress is rendering the component in the DOM)
- Change the response of `mount()` to a new object that includes the following:
    - the static TestBed
    - the fixture
    - the componentInstance
- Makes `mount()` async so that it doesn't return until the `fixture.whenStable()` has completed

Releases: 0.0.5