### PR TITLE
fix(angular): update mount function and add MountResponse to exports

### DIFF
--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-angular-component-testing",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",

--- a/projects/angular/src/public-api.ts
+++ b/projects/angular/src/public-api.ts
@@ -2,5 +2,5 @@
  * Public API Surface of angular
  */
 
-export { mount } from './lib/mount';
+export { mount, MountResponse } from './lib/mount';
 export * from './support'

--- a/src/app/app.component.cy.ts
+++ b/src/app/app.component.cy.ts
@@ -1,14 +1,23 @@
 import { RouterTestingModule } from '@angular/router/testing';
-import { mount } from 'cypress-angular-component-testing';
+import { mount, MountResponse } from 'cypress-angular-component-testing';
 import { AppComponent } from './app.component';
 import { AppModule } from './app.module';
 
 describe('AppComponent', () => {
+  let response: MountResponse<AppComponent>;
+
   beforeEach(async () => {
-    await mount(AppComponent, { imports: [AppModule, RouterTestingModule] });
+    const config = { imports: [AppModule, RouterTestingModule] }
+    response = await mount(AppComponent, config);
   });
 
   it('can mount', () => {
     cy.get('footer').contains('Love Angular');
+  })
+
+  it('does NOT show footer when show prop is false', () => {
+    response.component.show = false;
+    response.fixture.detectChanges();
+    cy.get('footer').should('not.exist')
   })
 });

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,12 +1,8 @@
 <app-toolbar title="Angular CT Demo App"></app-toolbar>
 
-<div class="content" role="main">
+<div *ngIf="show" class="content" role="main">
   <router-outlet></router-outlet>
   
-  <!-- <app-test-output-button></app-test-output-button>
-
-  <app-observables></app-observables> -->
-
   <app-footer></app-footer>
 
   <app-clouds></app-clouds>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,4 +7,5 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'angular-ct';
+  show = true;
 }

--- a/src/app/count/observables/observables.component.cy.ts
+++ b/src/app/count/observables/observables.component.cy.ts
@@ -1,3 +1,4 @@
+import { fakeAsync, tick } from "@angular/core/testing";
 import { mount } from "cypress-angular-component-testing";
 import { MountResponse } from "projects/angular/src/lib/mount";
 import { filter } from "rxjs/operators";
@@ -24,11 +25,11 @@ describe('Observables', () => {
         cy.get('h3').contains('Observable Service Count: 1');
     })
 
-    it('can decrement the count by clicking the subtract button which updates the observables next value in the service and it renders the new value in the component', () => {
+    it('can decrement the count by clicking the subtract button which updates the observables next value in the service and it renders the new value in the component', fakeAsync(() => {
         cy.get('h3').contains('Observable Service Count: 0');
         cy.get('button').contains('Subtract -').click();
         response.component.count$.pipe(filter(val => val < 0)).subscribe(() => response.fixture.detectChanges())
-        response.fixture.detectChanges();
+        tick()
         cy.get('h3').contains('Observable Service Count: -1')   
-    })
+    }))
 })


### PR DESCRIPTION
This PR does the following:
- Adds the `MountResponse` as part of the lib's exports
- Releases 0.0.6
- Adds the component to the modules declarations by default
- Call `. compileComponents()` on the testBed
    - I originally removed this as I didn't think it was necessary but it turns out that the module's metadata doesn't get added to the test if not
- Add tests example using `fakeAsync`