### PR TITLE
fix(angular-dev-server): adds stable support for angular v 12

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/projects/angular-dev-server/package.json
+++ b/projects/angular-dev-server/package.json
@@ -1,11 +1,11 @@
 {
   "name": "cypress-angular-dev-server",
-  "version": "0.0.26",
+  "version": "0.0.28",
   "peerDependencies": {
-    "@angular/common": ">=12",
-    "@angular/core": ">=12",
-    "@angular/compiler-cli": ">=12",
-    "@ngtools/webpack": ">=12",
+    "@angular/common": "~12",
+    "@angular/core": "~12",
+    "@angular/compiler-cli": "~12",
+    "@ngtools/webpack": "~12",
     "@cypress/webpack-dev-server": ">=1.8.2",
     "raw-loader": "~4.0.2",
     "babel-loader": "~8.2.3"

--- a/projects/angular-dev-server/src/lib/getWebpackConfig.ts
+++ b/projects/angular-dev-server/src/lib/getWebpackConfig.ts
@@ -2,7 +2,7 @@ import { AngularWebpackPlugin } from "@ngtools/webpack";
 import { Configuration } from "webpack";
 
 export async function getWebpackConfig(tmpDir: string): Promise<Configuration> {
-  const linkerPlugin = await import('@angular/compiler-cli/linker/babel');
+  // const linkerPlugin = await import('@angular/compiler-cli/linker/babel');
 
   return {
       mode: 'development',
@@ -24,17 +24,17 @@ export async function getWebpackConfig(tmpDir: string): Promise<Configuration> {
             test: /\.html$/,
             loader: 'raw-loader'
           },
-          {
-            test: /\.m?js$/,
-            use: {
-              loader: 'babel-loader',
-              options: {
-                plugins: [linkerPlugin.default],
-                compact: false,
-                cacheDirectory: true,
-              }
-            }
-          }
+          // {
+          //   test: /\.m?js$/,
+          //   use: {
+          //     loader: 'babel-loader',
+          //     options: {
+          //       plugins: [linkerPlugin.default],
+          //       compact: false,
+          //       cacheDirectory: true,
+          //     }
+          //   }
+          // }
         ],
       },
       resolve: {


### PR DESCRIPTION
This PR locks the dev server to support just v 12 of angular for the time being. Angular 11 and below uses webpack 4 which is incompatible with this lib and version 13 uses full IVY which isn't working currently. This releases a stable version for people to use in the time being:

Release `0.0.28`