### PR TITLE
fix(app): use real NgRx instance

### DIFF
--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-angular-component-testing",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",

--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -46,7 +46,6 @@ function initTestBed<T extends object>(component: Type<T>, config: TestBedConfig
     
   testBed.configureTestingModule({
     ...bootstrapModule(component, config),
-    // teardown: { destroyAfterEach: true }
   });
     
   return testBed;

--- a/src/app/count/count.component.cy.ts
+++ b/src/app/count/count.component.cy.ts
@@ -6,11 +6,14 @@ import { ObservablesComponent } from "./observables/observables.component"
 import { ObservablesService } from "./observables/observables.service"
 import { OverridesComponent } from "./overrides/overrides.component"
 import { TestOutputButtonComponent } from "./test-output-button/test-output-button.component"
+import { StoreModule } from '@ngrx/store';
+import { CountStoreModule } from './count-store/count-store.module';
 
 describe('CountComponent', () => {
     const config: TestBedConfig<CountComponent> = {
         declarations: [TestOutputButtonComponent, ObservablesComponent, NgrxCounterComponent, OverridesComponent],
-        providers: [ObservablesService, provideMockStore()]
+        providers: [ObservablesService],
+        imports: [StoreModule.forRoot({}, {}), CountStoreModule]
     }
 
     it('can click the child Button that updates state (triggers change detection)', () => {

--- a/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
+++ b/src/app/count/ngrx-counter/ngrx-counter.component.cy.ts
@@ -1,25 +1,15 @@
-import { MockStore, provideMockStore } from "@ngrx/store/testing";
-import { MountResponse } from '../../../../projects/angular/src/lib/mount';
-import { decrementCount, incrementCount } from '../count-store/count.actions';
+import { StoreModule } from "@ngrx/store";
+import { CountStoreModule } from "../count-store/count-store.module";
 import { NgrxCounterComponent } from "./ngrx-counter.component";
 
 describe('NgRxCounterComponent', () => {
-    const initialState = {
-        count: {
-            count: 0
-        }
-    }
-
-    let store: MockStore;
-    let response: MountResponse<NgrxCounterComponent>;
-
     beforeEach(() => {
         cy.mount(NgrxCounterComponent, {
-            providers: [provideMockStore({ initialState })]
-        }).then(res => {
-            response = res;
-            store = response.testBed.inject(MockStore)
-        });
+            imports: [
+                StoreModule.forRoot({}, {}),
+                CountStoreModule
+            ]
+        })
     })
     it('can mount', () => {
         cy.get('h3').contains('NgRx Counter: 0');
@@ -27,27 +17,13 @@ describe('NgRxCounterComponent', () => {
 
     it('can increment the count by dispatching action and selectors updates using MockStore.setState', () => {
         cy.get('h3').contains('NgRx Counter: 0');
-        cy.spy(store, 'dispatch').as('mockStoreSpy')
-        cy.get('button').contains('Increment +').click();
-        cy.get('@mockStoreSpy').should('have.been.calledWith', incrementCount()).then(() => {
-            store.setState({ count: { count: 100 }})
-            response.fixture.detectChanges();
-        });
-        
-        cy.get('h3').contains('NgRx Counter: 100');
+        cy.get('button').contains('Increment +').click()
+        cy.get('h3').contains('NgRx Counter: 1');
     })
 
     it('can decrement the count by dispatching action and selectors updates using MockStore.setState', () => {
         cy.get('h3').contains('NgRx Counter: 0')
-        cy.spy(store, 'dispatch').as('mockStoreSpy');
         cy.get('button').contains('Decrement -').click();
-        cy.get('@mockStoreSpy').should('have.been.calledWith', decrementCount());
-        // TODO create a custom commond that takes a function and calls changeDetection automatically
-        // cy.wrapAndRun(store.setState({ count: 100 }));
-        cy.wrap(store).then(() => {
-            store.setState({ count: { count: -10 }})
-            response.fixture.detectChanges();
-        })
-        cy.get('h3').contains('NgRx Counter: -10')
+        cy.get('h3').contains('NgRx Counter: -1')
     })
 })


### PR DESCRIPTION
The current NgRx tests are using `MockStore` which actually doesn't pass actions to the reducer and therefore doesn't update Component State via selectors. In order to demonstrate this working we need to use the real `StoreModule`