### PR TITLE
fix(angular): remove duplicate imports of CommonModule on mount

### DIFF
--- a/projects/angular-dev-server/src/lib/getWebpackConfig.ts
+++ b/projects/angular-dev-server/src/lib/getWebpackConfig.ts
@@ -41,7 +41,8 @@ export async function getWebpackConfig(tmpDir: string): Promise<Configuration> {
       },
       plugins: [
           new AngularWebpackPlugin({
-              tsconfig: `${tmpDir}/tsconfig.cy.json`
+              tsconfig: `${tmpDir}/tsconfig.cy.json`,
+              jitMode: true
           }),
       ],
     }

--- a/projects/angular/src/lib/mount.ts
+++ b/projects/angular/src/lib/mount.ts
@@ -29,7 +29,11 @@ export function bootstrapModule<T extends object>(component: Type<T>, config: Te
 
 
   testModuleMetaData.declarations.push(component)
-  testModuleMetaData.imports.push(CommonModule);
+
+  if (!testModuleMetaData.imports.includes(CommonModule)) {
+    testModuleMetaData.imports.push(CommonModule);
+  }
+
   return testModuleMetaData;
 }
 


### PR DESCRIPTION
Currently the `CommonModule` is being added in some cases multiple times to the `TestBedConfig`. This adds a check to only add it if it doesn't already exist in the imports array