### PR TITLE
fix(angular-dev-server): uses newest version of @cypress/webpack-dev-server

### DIFF
--- a/projects/angular-dev-server/package.json
+++ b/projects/angular-dev-server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-angular-dev-server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "peerDependencies": {
     "@angular/common": ">=12",
     "@angular/core": ">=12",
     "@angular/compiler-cli": ">=12",
     "@ngtools/webpack": ">=12",
-    "@cypress/webpack-dev-server": ">=1.8.2",
+    "@cypress/webpack-dev-server": ">=2.0.0",
     "raw-loader": "~4.0.2",
     "babel-loader": "~8.2.3"
   },


### PR DESCRIPTION
This PR updates the minimum required `@cypress/webpack-dev-server` to `2.0.0` .
